### PR TITLE
Fix build failures related to tests and ffmpeg tmp dir

### DIFF
--- a/src/short-creator/libraries/FFmpeg.ts
+++ b/src/short-creator/libraries/FFmpeg.ts
@@ -1,5 +1,6 @@
 import ffmpeg from "fluent-ffmpeg";
 import { Readable } from "node:stream";
+import { tmpdir } from "node:os";
 import { logger } from "../../logger";
 
 export class FFMpeg {
@@ -100,7 +101,7 @@ export class FFMpeg {
         .on("end", () => {
           resolve(outputPath);
         })
-        .mergeToFile(outputPath);
+        .mergeToFile(outputPath, tmpdir());
     });
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,5 +4,5 @@
     "outDir": "./dist"
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "src/ui"]
+  "exclude": ["**/*.test.*", "src/ui"]
 }


### PR DESCRIPTION
## Summary
- exclude skipped test files from build to avoid missing dependencies
- supply tmp directory to ffmpeg's mergeToFile to satisfy type expectations

## Testing
- `pnpm build`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9baa9243083229cc80217bae9e4d7